### PR TITLE
Add 'panGesturesEnabled' property

### DIFF
--- a/MCPanelViewController/MCPanelViewController.h
+++ b/MCPanelViewController/MCPanelViewController.h
@@ -26,6 +26,7 @@ typedef NS_ENUM(NSInteger, MCPanelBackgroundStyle) {
 @property (strong, nonatomic) UIColor *tintColor;
 @property (assign, nonatomic) MCPanelBackgroundStyle backgroundStyle;
 @property (assign, nonatomic, getter = isMasking) BOOL masking;
+@property (nonatomic, assign) BOOL panGesturesEnabled;
 
 - (id)initWithRootViewController:(UIViewController *)controller;
 - (void)presentInViewController:(UIViewController *)controller withDirection:(MCPanelAnimationDirection)direction;

--- a/MCPanelViewController/MCPanelViewController.m
+++ b/MCPanelViewController/MCPanelViewController.m
@@ -89,9 +89,6 @@ const static NSString *MCPanelViewGestureAnimationDirectionKey = @"MCPanelViewGe
             controller.view.backgroundColor = [UIColor clearColor];
         }
 
-        self.panGestureRecognizer = [[MCPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
-        self.panGestureRecognizer.direction = MCPanGestureRecognizerDirectionHorizontal;
-        [self.rootViewController.view addGestureRecognizer:self.panGestureRecognizer];
         [self commonInit];
     }
     return self;
@@ -120,6 +117,8 @@ const static NSString *MCPanelViewGestureAnimationDirectionKey = @"MCPanelViewGe
     
     [self.view addSubview:self.shadowView];
     [self.view addSubview:self.imageView];
+  
+    [self setPanGesturesEnabled:YES];
 }
 
 - (void)setMasking:(BOOL)masking {
@@ -130,6 +129,22 @@ const static NSString *MCPanelViewGestureAnimationDirectionKey = @"MCPanelViewGe
     else {
         self.backgroundButton.backgroundColor = [UIColor clearColor];
     }
+}
+
+- (void)setPanGesturesEnabled:(BOOL)panGesturesEnabled {  
+  if( panGesturesEnabled == _panGesturesEnabled )
+    return;
+  
+  _panGesturesEnabled = panGesturesEnabled;
+  
+  if( _panGesturesEnabled && !self.panGestureRecognizer ) {
+    self.panGestureRecognizer = [[MCPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
+    self.panGestureRecognizer.direction = MCPanGestureRecognizerDirectionHorizontal;
+    [self.rootViewController.view addGestureRecognizer:self.panGestureRecognizer];
+  } else if( !_panGesturesEnabled && self.panGestureRecognizer ) {
+    [self.rootViewController.view removeGestureRecognizer:self.panGestureRecognizer];
+    self.panGestureRecognizer = nil;
+  }
 }
 
 - (void)layoutSubviewsToWidth:(CGFloat)width {


### PR DESCRIPTION
Thanks for a great component!

I'm using `MCPanelViewController` in an iPhone app and the pan-to-dismiss behavior is not desirable for me because
- My presented panel view controllers are always full-screen, and 
- I'm using a navigation controller with a 'Done' button that performs some custom logic in addition to dismissing the panel.

I've added a `panGesturesEnabled` property that will enable (or disable) the pan gesture recognizer on the presented panel.
